### PR TITLE
Make room for speech bubbles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,6 @@ export default {
 
 <style>
 body {
-width: 100%;
  background: #f2f2f2;
  font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
  font-size: 16px;
@@ -31,7 +30,8 @@ width: 100%;
 
 html, body, #app{
    position: relative;
-   height: 100%;
+   width: 100vw;
+   height: 100vh;
 }
 
 #app {
@@ -40,7 +40,5 @@ html, body, #app{
   -moz-osx-font-smoothing: grayscale;
   text-align: center;
   color: #2c3e50;
-  width: 100%;
-
 }
 </style>

--- a/src/components/AnimPanel.vue
+++ b/src/components/AnimPanel.vue
@@ -1,11 +1,14 @@
 <template lang="html">
   <div class="panel animated" :class="panel.name">
-    <img :class="panel.effect" :style="{ 'transform': 'translate('+panel.position+')', 'min-width': panel.size, 'max-width': panel.size }" :src="panelBgArt" :alt="panel.name">
+    <img :class="panel.effect" :style="{ 'min-width': panel.size, 'min-height': panel.size }" :src="panelBgArt" :alt="panel.name">
   </div>
 
 </template>
 
 <script>
+// :class="panel.effect"
+// 'transform': 'translate('+panel.position+')',
+// :style="{ 'min-width': panel.size, 'min-height': panel.size }"
 import panelBgArt from './mixins';
 
 export default {
@@ -32,8 +35,15 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style scoped lang="scss">
 .animated {
+  img {
+    flex: 1 1 0;
+    align-items: stretch;
+    // object-fit: cover;
+
+  //  align-items: stretch;
+  }
   //--- SIMPLE PANEL ANIMS ---//
   .rotate {
     transition-property: transform;
@@ -44,8 +54,8 @@ export default {
   }
 
   @keyframes rotate {
-    from {transform: translate(-32%, -30%) rotate(0deg) ;}
-      to {transform: translate(-32%, -30%) rotate(360deg) ;}
+    from { transform: translate(-32%, -30%) rotate(0deg) ;}
+      to { transform: translate(-32%, -30%) rotate(360deg) ;}
   }
 
 }

--- a/src/components/Row.vue
+++ b/src/components/Row.vue
@@ -64,7 +64,7 @@ export default {
         border-color: #333333;
         position:relative;
 
-        display: flex;
+         display: flex;
 
         .paneltitle {
           position: absolute;
@@ -81,12 +81,12 @@ export default {
 
           }
         }
-          // img {
-          //   // width:100%;
-          //   //height: inherit;
-          //   padding: 0;
-          //   margin:0;
-          // }
+          img {
+            // width:100%;
+            //height: inherit;
+            padding: 0;
+            margin:0;
+          }
      }
        .panel + .panel {
          margin-left: 3%;

--- a/src/components/Row.vue
+++ b/src/components/Row.vue
@@ -63,6 +63,9 @@ export default {
         border-width: 2px;
         border-color: #333333;
         position:relative;
+
+        display: flex;
+
         .paneltitle {
           position: absolute;
           right:0;
@@ -78,12 +81,12 @@ export default {
 
           }
         }
-          img {
-            // width:100%;
-            //height: inherit;
-            padding: 0;
-            margin:0;
-          }
+          // img {
+          //   // width:100%;
+          //   //height: inherit;
+          //   padding: 0;
+          //   margin:0;
+          // }
      }
        .panel + .panel {
          margin-left: 3%;

--- a/src/components/StaticPanel.vue
+++ b/src/components/StaticPanel.vue
@@ -1,5 +1,7 @@
 <template lang="html">
-  <img class="panel" :class="panel.name" :style="{'flex-grow': panel.grow, 'object-fit': 'cover', 'object-position': panel.position }" :src="panelBgArt" :alt="panel.name">
+  <div class="panel static" :style="{ 'flex-grow': panel.grow }">
+    <img :class="panel.name" :style="{ 'object-position': panel.position }" :src="panelBgArt" :alt="panel.name">
+  </div>
 </template>
 
 <script>
@@ -23,6 +25,7 @@ export default {
 
   },
   created() {
+    // getPanelSize
 
   },
   mounted() {
@@ -32,5 +35,15 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.static {
+  img {
+    min-width: 0%;
+    min-height: 0%;
+    flex: 1 1 0;
+    align-items: stretch;
+    object-fit: cover;
+  }
+}
+
 
 </style>


### PR DESCRIPTION
Images are now (probably) correctly positioned inside divs without breaking {object-fit: cover}. Not tested on real device though